### PR TITLE
Release

### DIFF
--- a/misc/led-strip-holder.scad
+++ b/misc/led-strip-holder.scad
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A small bracket that will hold a LED strip.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+use <../lib/camelSCAD/shapes.scad>
+
+// To be able to use the library shared constants we import the definition file.
+include <../lib/camelSCAD/core/constants.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;
+
+// Defines the constraints of the object.
+ledStripWidth = 8.5;
+ledStripThickness = .5;
+screwDiameter = 3;
+thickness = 1;
+ledStripPadding = 1;
+screwPadding = 1.5;
+
+// Defines the dimensions of the object.
+groove = ceilBy(ledStripThickness, printResolution);
+length = ledStripWidth + screwDiameter + 2 * screwPadding + ledStripPadding;
+width = screwDiameter + 2 * screwPadding;
+height = ceilBy(thickness - ledStripThickness, printResolution) + groove;
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    difference() {
+        // main shape
+        union() {
+            translateX(width / 4) {
+                box(size=[length - width / 2, width, height]);
+            }
+            translateX(-(length - width) / 2) {
+                cylinder(d=width, h=height);
+            }
+        }
+        // make room for the LED strip
+        translate([(length - ledStripWidth) / 2 - ledStripPadding, 0, height - groove]) {
+            box(size=[ledStripWidth, width + ALIGN2, groove + ALIGN]);
+        }
+        // drill the hole for the screw
+        translate([screwPadding - (length - screwDiameter) / 2, 0, -ALIGN]) {
+            cylinder(d=screwDiameter, h=height + ALIGN2);
+        }
+    }
+}

--- a/misc/triominos-holder.scad
+++ b/misc/triominos-holder.scad
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A parametric holder for triominos.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+use <../lib/camelSCAD/shapes.scad>
+
+// To be able to use the library shared constants we import the definition file.
+include <../lib/camelSCAD/core/constants.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;  // the target layer height
+nozzle = 0.4;           // the size of the print nozzle
+wallDistance = 0.1;     // the distance between the walls of two objects
+
+// Defines the constraints of the object.
+// - size of a piece
+pieceWidth = 38;
+pieceHeight = 28;
+pieceThickness = 9;
+// - size of a board
+pieceInterval = 1;
+piecesByBoard = 5;
+boardThickness = 2;
+// size of the groove in which the board will be plugged
+grooveWall = 3 * nozzle;
+grooveDepth = 2;
+// - constraints of the holder
+boardCount = 2;
+boardAngle = 55;
+
+// Defines the dimensions of the object.
+boardInterval = pieceHeight * 1.3;
+
+/**
+ * The edge of a board that will support a range of pieces
+ * @param Number width
+ * @param Number height
+ * @param Number thickness
+ * @param Number count
+ */
+module standBoardEdge(width, height, thickness, count, distance=0) {
+    polygon(
+        points=outline(points=path(
+            p=concat([
+                ["P", 0, 0],
+                ["H", thickness]
+            ], flatten([
+                for(i = [0 : count - 1]) [
+                    ["H", width + thickness],
+                    ["V", height]
+                ]
+            ]), [
+                ["V", thickness],
+                ["H", -thickness]
+            ], flatten([
+                for(i = [0 : count - 1]) [
+                    ["V", -height],
+                    ["H", -width - thickness]
+                ]
+            ]))
+        ), distance=distance),
+        convexity=10
+    );
+}
+
+/**
+ * The side of a board that will support a range of pieces
+ * @param Number width
+ * @param Number height
+ * @param Number thickness
+ * @param Number wall
+ * @param Number depth
+ * @param Number angle
+ * @param Number count
+ */
+module standBoardSide(width, height, thickness, wall, depth, angle, count) {
+    rotateAngle = -(90 - angle);
+
+    margin = thickness + wall * 2;
+    outerWidth = (width + thickness) * count + margin;
+    outerHeight = height * count + margin;
+    outerThickness = thickness + depth;
+
+    pivot = width + thickness + margin;
+    axle = [outerWidth, outerHeight] - vector2D(margin / 2);
+    leg = rotp(axle - [pivot, 0], rotateAngle);
+
+    translateX(pivot * cos(rotateAngle)) {
+        rotateZ(rotateAngle) {
+            translate([wall - pivot, wall, 0]) {
+                difference() {
+                    // outline
+                    negativeExtrude(height=outerThickness) {
+                        // side
+                        standBoardEdge(width, height, thickness, count, distance=wall);
+
+                        // leg
+                        translate(axle - [wall, wall]) {
+                            rotateZ(-rotateAngle) {
+                                translateY((outerThickness / 2 - leg[1]) / 2) {
+                                    stadium(size=[outerThickness, leg[1] + outerThickness / 2], d=outerThickness);
+                                }
+                            }
+                        }
+                    }
+
+                    // groove
+                    translateZ(thickness) {
+                        negativeExtrude(height=outerThickness) {
+                            standBoardEdge(width, height, thickness, count);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A board that will support a range of pieces
+ * @param Vector pieceSize
+ * @param Number count
+ * @param Number thickness
+ * @param Number padding
+ */
+module standBoard(pieceSize, count, thickness, padding) {
+    pieceSize = vector3D(pieceSize);
+    half = thickness / 2;
+    depth = roundBy(half, printResolution);
+
+    grooveDepth = depth + printResolution;
+    grooveWidth = half;
+
+    ridgeHeight = depth - printResolution;
+    ridgeWidth = half;
+
+    outerLength = pieceSize[0] * count + padding * 2;
+    outerWidth = pieceSize[1] + thickness;
+    outerHeight = pieceSize[2] + thickness + ridgeHeight;
+
+    difference() {
+        // board
+        box([outerLength, outerWidth, outerHeight]);
+        translate([0, thickness, thickness]) {
+            box([outerLength + ALIGN2, outerWidth, outerHeight]);
+        }
+
+        // ridge
+        translate([0, thickness - (outerWidth + ridgeWidth) / 2, outerHeight - ridgeHeight]) {
+            box(vadd([outerLength, ridgeWidth, ridgeHeight], ALIGN2));
+        }
+
+        // groove
+        translate([0, (outerWidth + grooveWidth) / 2 - thickness, -ALIGN]) {
+            box(vadd([outerLength, grooveWidth, grooveDepth], ALIGN2));
+        }
+    }
+}
+
+
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+
+    // sides
+    translateY(((boardCount - 1) * boardInterval) / 2) {
+        repeatMirror(count=2) {
+            translateX(pieceThickness) {
+                standBoardSide(
+                    width = pieceThickness,
+                    height = pieceHeight,
+                    thickness = boardThickness,
+                    wall = grooveWall,
+                    depth = grooveDepth,
+                    angle = boardAngle,
+                    count = boardCount
+                );
+            }
+        }
+    }
+
+    // boards
+    translateY(-(boardCount * boardInterval) / 2) {
+        repeat(count=boardCount, interval=[0, boardInterval, 0]) {
+            standBoard(
+                pieceSize = [
+                    pieceWidth + pieceInterval,
+                    pieceHeight,
+                    pieceThickness
+                ],
+                count = piecesByBoard,
+                thickness = boardThickness,
+                padding = grooveDepth
+            );
+        }
+    }
+
+}

--- a/misc/wires-separator.scad
+++ b/misc/wires-separator.scad
@@ -2,7 +2,7 @@
  * @license
  * GPLv3 License
  *
- * Copyright (c) 2018 Jean-Sebastien CONAN
+ * Copyright (c) 2018-2019 Jean-Sebastien CONAN
  *
  * This file is part of jsconan/things.
  *
@@ -58,7 +58,7 @@ plateHeight = flat ? plateEdge : max(flangeHeight, plateEdge, gouged ? plateEdge
 module wireHole(wireDiameter, aperturePercent) {
     wireRadius = wireDiameter / 2;
     apertureWidth = wireDiameter * max(0, min(aperturePercent, 100)) / 100;
-    apertureDistance = pythagore(b=apertureWidth / 2, c=wireRadius);
+    apertureDistance = pythagoras(b=apertureWidth / 2, c=wireRadius);
     apertureHeight = wireRadius - apertureDistance;
     aperturePos = apertureDistance + apertureHeight / 2;
 

--- a/printer/dehydratator-feet.scad
+++ b/printer/dehydratator-feet.scad
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A feet set to put under a cylindric food dehydratator.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+use <../lib/camelSCAD/shapes.scad>
+
+// To be able to use the library shared constants we import the definition file.
+include <../lib/camelSCAD/core/constants.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;
+
+// Defines the constraints of the object.
+dehydratatorFootWidth = 14;
+dehydratatorFootThickness = 3;
+dehydratatorFootHeight = 8;
+topWidthDiff = .2;
+topThicknessDiff = .2;
+wallThickness = 2;
+count = 4;
+
+// Defines the dimensions of the object.
+additionalThickness = wallThickness * 2;
+footWidth = dehydratatorFootWidth + additionalThickness;
+footThickness = dehydratatorFootThickness + additionalThickness;
+footHeight = roundBy(dehydratatorFootHeight + wallThickness, printResolution);
+intervalX = footThickness + wallThickness;
+
+/**
+ * @param Vector bottom
+ * @param Vector top
+ * @param Number height
+ */
+module foot(bottom, top, height) {
+    hull() {
+        slot(size=bottom, h=ALIGN, d=bottom[0]);
+        translateZ(height - ALIGN) {
+            slot(size=top, h=ALIGN, d=top[0]);
+        }
+    }
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    translateX(-((count - 1) * intervalX) / 2) {
+        repeat(
+            count=count,
+            interval=[intervalX, 0, 0]
+        ) {
+            difference() {
+                foot(
+                    bottom=[footThickness, footWidth],
+                    top=[footThickness + topThicknessDiff, footWidth + topWidthDiff],
+                    height=footHeight
+                );
+                translateZ(footHeight - dehydratatorFootHeight) {
+                    foot(
+                        bottom=[dehydratatorFootThickness, dehydratatorFootWidth],
+                        top=[dehydratatorFootThickness + topThicknessDiff, dehydratatorFootWidth + topWidthDiff],
+                        height=dehydratatorFootHeight + ALIGN
+                    );
+                }
+            }
+        }
+    }
+}

--- a/printer/dehydratator-spool-holder.scad
+++ b/printer/dehydratator-spool-holder.scad
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A spool holder that mounts on a cylindric food dehydratator.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+use <../lib/camelSCAD/shapes.scad>
+
+// To be able to use the library shared constants we import the definition file.
+include <../lib/camelSCAD/core/constants.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;
+
+// Defines the constraints of the object.
+mountDiameter = 79;
+mountDepth = 5;
+mountWall = 5;
+
+plateThickness = 5;
+plateRidgeWidth = 1;
+plateRidgeHeight = .5;
+plateRidgeCount = 4;
+
+spoolHoleDiameter = 50;
+spoolHoleHeight = 30;
+spoolHoleChamfer = 1;
+spoolHoleRidgeWidth = 1;
+spoolHoleRidgeHeight = .5;
+spoolHoleRidgeCount = 6;
+
+// Defines the dimensions of the object.
+plateHeight = roundBy(plateThickness + mountDepth - plateRidgeHeight, printResolution);
+plateDiameter = mountDiameter + mountWall * 2;
+plateBrim = (plateDiameter - spoolHoleDiameter) / 2;
+plateRidgeInterval = plateBrim / plateRidgeCount - plateRidgeWidth;
+plateRidgeX = plateRidgeWidth / 2 * cos(60);
+plateRidgeY = plateRidgeHeight;
+
+spoolHoleInnerDiameter = spoolHoleDiameter - spoolHoleRidgeHeight * 2;
+spoolHoleRidgeInterval = (spoolHoleHeight - spoolHoleRidgeWidth) / spoolHoleRidgeCount - spoolHoleRidgeWidth;
+spoolHoleRidgeX = spoolHoleRidgeHeight;
+spoolHoleRidgeY = spoolHoleRidgeWidth / 2 * cos(60);
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    //sample(size=vadd([plateDiameter, plateDiameter, 8], ALIGN2), offset=[0, 0, -ALIGN])
+    //sample(size=vadd([plateDiameter, plateDiameter, 8], ALIGN2), offset=[0, 0, plateHeight+spoolHoleHeight-8-ALIGN])
+    rotate_extrude() {
+        polygon(
+            points=path(concat([
+                // mount side
+                ["P", 0, mountDepth],
+                ["H", mountDiameter / 2],
+                ["V", -mountDepth],
+                ["H", mountWall],
+
+                // plate side
+                ["V", plateHeight]
+            ], flatten([
+                for(i=[0:plateRidgeCount - 1]) [
+                    ["L", -plateRidgeInterval * and(i, 1), 0],
+                    ["L", - plateRidgeX, plateRidgeY],
+                    ["H", - plateRidgeWidth + plateRidgeX * 2],
+                    ["L", - plateRidgeX, -plateRidgeY]
+                ]
+            ]), [
+                // spool hole side
+                ["P", spoolHoleInnerDiameter / 2, plateHeight],
+            ], flatten([
+                for(i=[1:spoolHoleRidgeCount]) [
+                    ["L", 0, spoolHoleRidgeInterval * and(i, 1)],
+                    ["L", spoolHoleRidgeX, spoolHoleRidgeY],
+                    ["V", spoolHoleRidgeWidth - spoolHoleRidgeY * 2],
+                    ["L", -spoolHoleRidgeX, spoolHoleRidgeY],
+                ]
+            ]), [
+                ["L", -spoolHoleChamfer, spoolHoleChamfer],
+                ["H", -spoolHoleInnerDiameter / 2 + spoolHoleChamfer],
+            ])),
+            convexity=10
+        );
+    }
+}

--- a/printer/wheel-spool-holder.scad
+++ b/printer/wheel-spool-holder.scad
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A spool holder that will be pluggable on the wheels of the adjustable
+ * spool holder from the LACK enclosure cabinet.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+use <../lib/camelSCAD/shapes.scad>
+
+// To be able to use the library shared constants we import the definition file.
+include <../lib/camelSCAD/core/constants.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;  // the target layer height
+nozzle = 0.4;           // the size of the print nozzle
+wallDistance = 0.1;     // the distance between the walls of two objects
+
+// Defines the constraints of the object.
+wheelWidth = 4.4;
+wheelDiameter = 24.5;
+wheelDistance = 80;
+wheelPadding = 5;
+spoolWidth = 100;
+spoolDiameter = 200;
+spoolHoleDiameter = 50;
+axleDiameter = 25;
+axleGrooveDepth = 3;
+axleEdge = 1;
+
+// Defines the dimensions of the object.
+axleGrooveDiameter = axleDiameter - axleGrooveDepth * 2;
+axleLength = (axleEdge + wheelWidth + axleGrooveDepth * 2) * 2 + wheelDistance;
+spoolHeight = (spoolDiameter + spoolHoleDiameter) / 2;
+spoolHolderLegWidth = wheelDistance + wheelDiameter + wheelPadding * 2;
+spoolHolderLegheight = spoolHeight + (axleGrooveDiameter + wheelDiameter) * 3 / 4 + wheelPadding * 2;
+
+/**
+ * Axle for the spool holder.
+ * @param Number diameter - the axle diameter
+ * @param Number interval - the interval between the legs
+ * @param Number groove - the width of the groove that will receive a leg
+ * @param Number depth - the depth of the groove that will receive a leg
+ * @param Number edge - the edge of the axle
+ */
+module spoolHolderAxle(diameter, interval, groove, depth=5, edge=1) {
+    rotate_extrude(angle = 360, convexity = 10) {
+        polygon(
+            points=path([
+                ["P", 0, 0],
+                ["H", diameter / 2],
+                ["V", edge],
+                ["L", -depth, depth],
+                ["V", groove],
+                ["L", depth, depth],
+                ["V", interval],
+                ["L", -depth, depth],
+                ["V", groove],
+                ["L", depth, depth],
+                ["V", edge],
+                ["H", -diameter / 2, 0],
+            ]),
+            convexity = 10
+        );
+    }
+}
+
+/**
+ * Leg for the spool holder.
+ * @param Number wheelDiameter - the diameter of a wheel on which the leg should stand
+ * @param Number wheelDistance - the distance between the wheels on which the leg should stand
+ * @param Number axleDiameter - the diameter of the axle that will fit on the legs
+ * @param Number axleDistance - the distance between the axle and the wheels
+ * @param Number width - The thickness of a leg
+ * @param Number padding - The padding around the wheels
+ */
+module spoolHolderLeg(wheelDiameter, wheelDistance, axleDiameter, axleDistance, width, padding) {
+    roundRadius = padding / 4;
+    overflow = padding / 2;
+    wheelRadius = wheelDiameter / 2;
+    axleRadius = axleDiameter / 2;
+    armWidth = wheelDiameter + padding * 2;
+    outerWidth = wheelDistance + wheelDiameter + padding * 2;
+    outerHeight = axleDistance + (axleDiameter + wheelDiameter) * 3 / 4 + padding * 2;
+    quarter = axleDistance / 4;
+    hollow = axleDistance * 3 / 5;
+
+    translateY(-axleDistance / 2) {
+        %union() {
+            translateY(wheelDistance / 2) rectangle(wheelDistance);
+            translateX(-wheelDistance / 2) repeat(interval=[wheelDistance]) circle(d=wheelDiameter);
+            translateY(axleDistance / 2) rectangle(axleDistance);
+            translateY(axleDistance) circle(d=axleDiameter);
+        }
+        negativeExtrude(width) {
+            repeatMirror() {
+                difference() {
+                    polygon(
+                        points=path([
+                            ["P", outerWidth / 2, 0],
+                            ["V", -overflow],
+                            ["C", roundRadius, 360, 270],
+                            ["H", -overflow],
+                            ["C", roundRadius, 270, 180],
+                            ["V", overflow],
+                            ["C", wheelRadius, 0, 180],
+                            ["V", -overflow],
+                            ["C", roundRadius, 360, 270],
+                            ["H", -overflow],
+                            ["C", roundRadius, 270, 180],
+                            ["V", overflow],
+                            ["C", [outerWidth / 2 - armWidth, quarter * 3], 0, 90],
+                            ["V", quarter - axleRadius],
+                            ["C", axleRadius, 270, 360],
+                            ["V", overflow],
+                            ["C", roundRadius, 180, 90],
+                            ["C", [(outerWidth - axleDiameter - overflow) / 2, axleDistance], 90, 0]
+                        ]),
+                        convexity = 10
+                    );
+                    polygon(
+                        points=path([
+                            ["P", (wheelDistance + wheelRadius) / 2, quarter],
+                            ["C", [wheelDiameter, hollow], 0, 90],
+                            ["C", [wheelDiameter, hollow], 180, 270],
+                        ]),
+                        convexity = 10
+                    );
+                }
+            }
+        }
+    }
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    union() {
+        translateY(spoolHolderLegheight / 4) {
+            spoolHolderAxle(
+                diameter = axleDiameter,
+                interval = spoolWidth + wheelPadding * 2,
+                groove = wheelWidth,
+                depth = axleGrooveDepth,
+                edge = axleEdge
+            );
+        }
+
+        translateX(-(spoolHolderLegWidth + wheelPadding) / 2) {
+            repeat(interval = [spoolHolderLegWidth + wheelPadding, 0, 0]) {
+                spoolHolderLeg(
+                    wheelDiameter = wheelDiameter,
+                    wheelDistance = wheelDistance,
+                    axleDiameter = axleGrooveDiameter,
+                    axleDistance = spoolHeight,
+                    width = wheelWidth,
+                    padding = wheelPadding
+                );
+            }
+        }
+    }
+}

--- a/rcmodels/betafpv-beta85x/betafpv-beta85x-needle.scad
+++ b/rcmodels/betafpv-beta85x/betafpv-beta85x-needle.scad
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A needle for the BetaFPV Beta85X HD,
+ * to activate the camera recording or
+ * to remove the SD card.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library
+include <../../lib/camelSCAD/shapes.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print
+printResolution = 0.2;
+
+// Defines the constraints of the object
+needleWidth = 2;
+needleLength = 20;
+needleThickness = 1.8;
+handleWidth = 15;
+handleLength = 60;
+
+// Defines the dimensions of the object
+needleSide = (handleWidth - needleWidth) / 2;
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+//sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 2], offset=[0, 0, 2])
+buildBox(mode=renderMode) {
+    negativeExtrude(needleThickness) {
+        polygon(
+            points=path([
+                ["P", handleWidth / 2, 0],
+                ["C", [needleSide, needleLength], 270, 180],
+                ["H", -needleWidth],
+                ["C", [needleSide, needleLength], 360, 270],
+                ["C", [handleWidth / 2, handleLength], 180, 360]
+            ]),
+            convexity = 10
+        );
+    }
+}

--- a/rcmodels/betafpv-beta85x/betafpv-beta85x-stand.scad
+++ b/rcmodels/betafpv-beta85x/betafpv-beta85x-stand.scad
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A stand for the BetaFPV Beta85X.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library
+include <../../lib/camelSCAD/shapes.scad>
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print
+printResolution = 0.2;
+
+// Defines the constraints of the object
+motorDistance = 85;
+pillarHeight = 30;
+pillarDiameter = 10;
+platformDiameter = 20;
+plateDiameter = 40;
+plateThickness = 3;
+
+// Defines the dimensions of the object
+armLength = (motorDistance - plateDiameter) / 2 + pillarDiameter;
+platformHeight = platformDiameter - pillarDiameter;
+pillarBottom = pillarHeight - platformHeight;
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+//sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 2], offset=[0, 0, 2])
+buildBox(mode=renderMode) {
+    // the base
+    negativeExtrude(height=plateThickness) {
+        ring(d=plateDiameter, w=pillarDiameter);
+        repeatRotate(count=4) {
+            translateY((armLength + plateDiameter - pillarDiameter) / 2) {
+                stadium(w=pillarDiameter, h=armLength, d=pillarDiameter);
+            }
+        }
+    }
+
+    // the pillars
+    repeatRotate(count=4) {
+        translate([motorDistance / 2, 0, plateThickness]) {
+            cylinder(d=pillarDiameter, h=pillarBottom);
+            translateZ(pillarBottom) {
+                cylinder(d1=pillarDiameter, d2=platformDiameter, h=platformHeight);
+            }
+        }
+    }
+}

--- a/rcmodels/blade-inductrix/tiny-whoop-camera-holder.scad
+++ b/rcmodels/blade-inductrix/tiny-whoop-camera-holder.scad
@@ -2,7 +2,7 @@
  * @license
  * GPLv3 License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2019 Jean-Sebastien CONAN
  *
  * This file is part of jsconan/things.
  *
@@ -41,12 +41,12 @@ screwDiameter =  2.0;
 
 motorInterval = 46.0;
 ductDiameter  = 37.0;
-ductInterval  = pythagore(motorInterval, motorInterval);
+ductInterval  = pythagoras(motorInterval, motorInterval);
 
 plateThickness =  0.6;
 plateRound     =  1.0;
 plateWidth     = 30.0;
-plateDiag      = pythagore(plateWidth, plateWidth);
+plateDiag      = pythagoras(plateWidth, plateWidth);
 
 cameraLength     = 15.0;
 cameraWidth      =  8.0;

--- a/rcmodels/blade-torrent-110/blade-torrent-stand.scad
+++ b/rcmodels/blade-torrent-110/blade-torrent-stand.scad
@@ -2,7 +2,7 @@
  * @license
  * GPLv3 License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2019 Jean-Sebastien CONAN
  *
  * This file is part of jsconan/things.
  *
@@ -60,7 +60,7 @@ pillarInterval = batteryWidth + padding;
 pillarGrooveWidth = armWidth + padding / 2;
 plateWidth = pillarInterval + sqrt(pow(pillarEmbossWidth, 2) / 2) * 2;
 plateRound = pillarThickness;
-armLength = pythagore(plateWidth, plateWidth);
+armLength = pythagoras(plateWidth, plateWidth);
 armOffset = pillarThickness;
 armSize = [(armLength - coreWidth) / 2 + armOffset, pillarWidth];
 armX = coreWidth / 2 - armOffset;

--- a/rcmodels/whoop-box/angled-box.scad
+++ b/rcmodels/whoop-box/angled-box.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Angled box that will contain a tiny-whoop and its surrounding protection box.
+ * This should be printed in rigid material, like PLA.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 5])
+    whoopAngledBox(
+        whoopType = whoopType,
+        wallThickness = getBoxWallThickness(ANGLED_BOX),
+        groundThickness = getBoxGroundThickness(ANGLED_BOX),
+        boxHeight = getBoxHeight(ANGLED_BOX, whoopType),
+        ductDistance = getBoxWhoopDistance(ANGLED_BOX)
+    );
+}

--- a/rcmodels/whoop-box/config/config.scad
+++ b/rcmodels/whoop-box/config/config.scad
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines the config.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// We will render the object using the specifications of this mode
+renderMode = MODE_PROD;
+
+// Defines the constraints of the print.
+printResolution = 0.2;  // the target layer height
+nozzle = 0.4;           // the size of the print nozzle
+wallDistance = 0.1;     // the distance between the walls of two objects
+
+// Defines the indexes in the datasets
+IDX_ID = 0;             // index of the identifier
+// - Tiny Whoop data
+IDX_WHOOP_DUCT = 1;     // index of the duct diameter in whoop data
+IDX_WHOOP_FRAME = 2;    // index of the frame diagonal in whoop data
+IDX_WHOOP_HEIGHT = 3;   // index of the height in whoop data
+// - Box data
+IDX_BOX_WALL = 1;       // index of the wall thickness in box data
+IDX_BOX_GROUND = 2;     // index of the ground thickness in box data
+IDX_BOX_HEIGHT = 3;     // index of the height addition in box data
+IDX_BOX_DISTANCE = 4;   // index of the distance to walls factor in box data
+
+// Defines the types of data
+TINY_WHOOP_65_BL = "tiny65bl";
+TINY_WHOOP_75_BL = "tiny75bl";
+ROUNDED_BOX = "rounded";
+ANGLED_BOX = "angled";
+CONTAINER = "drawer";
+DRAWER = "drawer";
+CUPBOARD = "cupboard";
+
+// Defines the size for each types of tiny-whoops
+whoopData = [
+    // id,             duct, frame, height
+    [TINY_WHOOP_65_BL,  37,   65,    48],
+    [TINY_WHOOP_75_BL,  48,   76,    48],
+];
+
+// Defines the constraints for the tiny-whoops boxes
+boxData = [
+    // id,         wall, ground, height addition, distance factor
+    [ROUNDED_BOX,   0.8,  1,     -1,               1],
+    [ANGLED_BOX,    1.0,  1,      0,               1],
+    [DRAWER,        1.6,  1,      1,               4],
+    [CUPBOARD,      2.0,  2,      0,               4],
+];
+
+// Defines the size of a box indentation
+boxIndentation = [30, 10];
+
+// Defines the size of a handle hole
+boxHandleHole = 20;
+
+// Defines the target tiny-whoop type
+whoopType = TINY_WHOOP_65_BL;
+
+// Sets the count of tiny-whoops in each kind of box
+whoopCountBox = 2;
+whoopCountDrawer = 2;
+drawerCountCupboard = 2;

--- a/rcmodels/whoop-box/container.scad
+++ b/rcmodels/whoop-box/container.scad
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Container box that will contain several tiny-whoops and their surrounding
+ * protection boxes. This should be printed in rigid material, like PLA or PETG.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 5])
+    whoopContainer(
+        whoopType = whoopType,
+        wallThickness = getBoxWallThickness(CONTAINER),
+        groundThickness = getBoxGroundThickness(CONTAINER),
+        boxHeight = getBoxHeight(CONTAINER, whoopType),
+        ductDistance = getBoxWhoopDistance(CONTAINER),
+        whoopCount = whoopCountBox
+    );
+}

--- a/rcmodels/whoop-box/cupboard.scad
+++ b/rcmodels/whoop-box/cupboard.scad
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Cupboard that will contain several tiny-whoops and their surrounding
+ * protection boxes. This should be printed in rigid a material, like PLA
+ * or PETG.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 20])
+    whoopCupboard(
+        whoopType = whoopType,
+        whoopCount = whoopCountDrawer,
+        drawerWallThickness = getBoxWallThickness(DRAWER),
+        drawerHeight = getBoxHeight(CUPBOARD, whoopType),
+        drawerCount = drawerCountCupboard,
+        drawerDistance = getBoxWallDistance(CUPBOARD),
+        ductDistance = getBoxWhoopDistance(DRAWER),
+        wallThickness = getBoxWallThickness(CUPBOARD)
+    );
+}

--- a/rcmodels/whoop-box/drawer.scad
+++ b/rcmodels/whoop-box/drawer.scad
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Drawer that will contain several tiny-whoops and their surrounding protection
+ * boxes. This should be printed in rigid a material, like PLA or PETG.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 5])
+    whoopDrawer(
+        whoopType = whoopType,
+        wallThickness = getBoxWallThickness(DRAWER),
+        groundThickness = getBoxGroundThickness(DRAWER),
+        boxHeight = getBoxHeight(DRAWER, whoopType),
+        ductDistance = getBoxWhoopDistance(DRAWER),
+        whoopCount = whoopCountDrawer
+    );
+}

--- a/rcmodels/whoop-box/render.sh
+++ b/rcmodels/whoop-box/render.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+#
+# GPLv3 License
+#
+# Copyright (c) 2019 Jean-Sebastien CONAN
+#
+# This file is part of jsconan/things.
+#
+# jsconan/things is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# jsconan/things is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Generates the STL files for the tiny-whoops boxes.
+#
+# @author jsconan
+#
+
+# application params
+whoop="tiny65bl"
+boxX=
+boxY=
+drawerX=
+drawerY=
+drawers=
+whoopCountBox=
+whoopCountDrawer=
+drawerCountCupboard=
+
+# script params
+output="output"
+fileext=".scad"
+
+# script config
+scriptPath=$(dirname $0)
+project=$(pwd)
+dstpath=${project}/${output}
+src=${project}/*${fileext}
+
+# color codes
+C_ERR="\033[31m"
+C_SEL="\033[32m"
+C_SPE="\033[33m"
+C_CTX="\033[36m"
+C_RST="\033[0m"
+C_MSG="\033[1m"
+C_INF="\033[32m"
+
+# renders a file
+# @param fileName
+render() {
+    dst="${dstpath}/${whoop}-$(basename $1 ${fileext}).stl"
+    echo -e "${C_RST}Rendering of ${C_SEL}$(basename $1)${C_RST} to ${C_SEL}${dst}"
+    openscad --render -o "${dst}" "$1" \
+        -D "renderMode=\"prod\"" \
+        -D "whoopType=\"${whoop}\"" \
+        -D "${whoopCountBox}" \
+        -D "${whoopCountDrawer}" \
+        -D "${drawerCountCupboard}"
+}
+
+echo -e "${C_RST}"
+
+# load parameters
+while (( "$#" )); do
+    case $1 in
+        "-t"|"--whoop")
+            whoop=$2
+            shift
+        ;;
+        "-x")
+            boxX=$2
+            drawerX=$2
+            shift
+        ;;
+        "-y")
+            boxY=$2
+            drawerY=$2
+            shift
+        ;;
+        "-b"|"--box")
+            boxX=$2
+            boxY=$2
+            shift
+        ;;
+        "-bx"|"--boxX")
+            boxX=$2
+            shift
+        ;;
+        "-by"|"--boxY")
+            boxY=$2
+            shift
+        ;;
+        "-d"|"--drawer")
+            drawerX=$2
+            drawerY=$2
+            shift
+        ;;
+        "-dx"|"--drawerX")
+            drawerX=$2
+            shift
+        ;;
+        "-dy"|"--drawerY")
+            drawerY=$2
+            shift
+        ;;
+        "-ds"|"--drawers")
+            drawers=$2
+            shift
+        ;;
+        "-h"|"--help")
+            echo -e "${C_INF}Renders OpenSCAD files${C_RST}"
+            echo -e "  ${C_INF}Usage:${C_RST}"
+            echo -e "${C_CTX}\t$0 [-h|--help] [-o|--option value] files${C_RST}"
+            echo
+            echo -e "${C_MSG}  -h,  --help         ${C_RST}Show this help"
+            echo -e "${C_MSG}  -t,  --whoop        ${C_RST}Set the type of tiny-whoop (tiny65bl, tiny75bl)"
+            echo -e "${C_MSG}  -x                  ${C_RST}Set the number of tiny-whoops in the length of a box and a drawer"
+            echo -e "${C_MSG}  -y                  ${C_RST}Set the number of tiny-whoops in the width of a box and a drawer"
+            echo -e "${C_MSG}  -b,  --box          ${C_RST}Set the number of tiny-whoops in both directions for a box"
+            echo -e "${C_MSG}  -bx, --boxX         ${C_RST}Set the number of tiny-whoops in the length of a box"
+            echo -e "${C_MSG}  -by, --boxY         ${C_RST}Set the number of tiny-whoops in the width of a box"
+            echo -e "${C_MSG}  -d,  --drawer       ${C_RST}Set the number of tiny-whoops in both directions for a drawer"
+            echo -e "${C_MSG}  -dx, --drawerX      ${C_RST}Set the number of tiny-whoops in the length of a drawer"
+            echo -e "${C_MSG}  -dy, --drawerY      ${C_RST}Set the number of tiny-whoops in the width of a drawer"
+            echo -e "${C_MSG}  -ds, --drawers      ${C_RST}Set the number of drawers"
+            echo
+            exit 0
+        ;;
+        *)
+            ls $1 >/dev/null 2>&1
+            if [ "$?" == "0" ]; then
+                src=$1
+            else
+                echo -e "${C_ERR}"
+                echo -e "${C_ERR}Unknown parameter ${1}${C_RST}"
+                echo -e "${C_RST}"
+                exit 1
+            fi
+        ;;
+    esac
+    shift
+done
+
+# compose value for the number of tiny-whoops per container
+if [ "${boxX}" != "" ] || [ "${boxY}" != "" ]; then
+    if [ "${boxX}" == "" ]; then
+        boxX="1"
+    fi
+    if [ "${boxY}" == "" ]; then
+        boxY="1"
+    fi
+    whoopCountBox="whoopCountBox=[${boxX}, ${boxY}]"
+fi
+
+# compose value for the number of tiny-whoops per drawer
+if [ "${drawerX}" != "" ] || [ "${drawerY}" != "" ]; then
+    if [ "${drawerX}" == "" ]; then
+        drawerX="1"
+    fi
+    if [ "${drawerY}" == "" ]; then
+        drawerY="1"
+    fi
+    whoopCountDrawer="whoopCountDrawer=[${drawerX}, ${drawerY}]"
+fi
+
+# compose value for the number of drawers
+if [ "${drawers}" != "" ]; then
+    drawerCountCupboard="drawerCountCupboard=${drawers}"
+fi
+
+# create the output folder if needed
+if [ ! -d "${dstpath}" ]; then
+    echo -e "${C_SEL}Create output folder.${C_RST}"
+    mkdir -p "${dstpath}" >/dev/null
+
+    if [ ! -d "${dstpath}" ]; then
+        echo -e "${C_ERR}"
+        echo "Cannot create output folder!"
+        echo -e "${C_RST}"
+        exit 1
+    fi
+fi
+
+# check OpenSCAD
+echo -e "Detecting ${C_SPE}OpenSCAD${C_RST}..."
+openscad -v >/dev/null 2>&1
+if [ "$?" != "0" ]; then
+    echo -e "${C_ERR}"
+    echo "It seems OpenSCAD has not been installed on your system."
+    echo "Or perhaps is it just not reachable..."
+    echo "Have you placed it in your environment PATH variable?"
+    echo -e "${C_RST}"
+    exit 3
+fi
+
+echo -e "${C_SPE}OpenSCAD${C_RST} has been detected."
+echo -e "${C_RST}"
+echo -e "${C_RST}Processing rendering from ${C_CTX}${project}"
+echo -e "${C_RST}"
+
+# render the files, if exist
+ls ${src} >/dev/null 2>&1
+if [ "$?" == "0" ]; then
+    for filename in ${src}; do
+        render "${filename}"
+    done
+else
+    echo -e "${C_ERR}"
+    echo "There is nothing to render!"
+    echo -e "${C_RST}"
+    exit 1
+fi
+
+echo -e "${C_RST}"
+echo "Done!"

--- a/rcmodels/whoop-box/rounded-box.scad
+++ b/rcmodels/whoop-box/rounded-box.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Rounded box that will directly contain a tiny-whoop.
+ * This should be printed in a soft and rubber material, like TPU.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 10], offset=[0, 0, 5])
+    whoopRoundedBox(
+        whoopType = whoopType,
+        wallThickness = getBoxWallThickness(ROUNDED_BOX),
+        groundThickness = getBoxGroundThickness(ROUNDED_BOX),
+        boxHeight = getBoxHeight(ROUNDED_BOX, whoopType),
+        ductDistance = getBoxWhoopDistance(ROUNDED_BOX)
+    );
+}

--- a/rcmodels/whoop-box/shapes/angled-box.scad
+++ b/rcmodels/whoop-box/shapes/angled-box.scad
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines angled box shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Computes the points defining a duct outline.
+ * Angled version.
+ * @param Vector point - The center of the duct
+ * @param Number duct - The duct diameter
+ * @param Number start - The start sector
+ * @param Number end - The end sector
+ * @param Number m - The number of sectors for the intermediate points
+ * @param Number n - The number of sectors for the surrounding points
+ * @returns Vector[]
+ */
+function drawWhoopAngledBoxDuct(point, duct, start, end, m = 8, n = 12) =
+    let(
+        point = vector2D(point),
+        angleM = getPolygonAngle(1, m),
+        angleN = getPolygonAngle(1, n),
+        radiusM = getDuctRadius(m, duct),
+        radiusN = getDuctRadius(n, duct),
+        start = float(start),
+        end = float(end),
+        startInternal = round(start * m / n),
+        endInternal = round(end * m / n) - 1
+    )
+    concat([
+        point + arcp(radiusN, start * angleN)
+    ], [
+        for (i = [startInternal : endInternal])
+            point + arcp(radiusM, (i + 0.5) * angleM)
+    ], [
+        point + arcp(radiusN, end * angleN)
+    ])
+;
+
+/**
+ * Computes the points defining the polygon shape surrounding a tiny-whoop.
+ * Angled version.
+ * @param Number duct - The duct diameter
+ * @param Number interval - The distance between ducts
+ * @returns Vector[]
+ */
+function drawWhoopAngledBoxShape(duct, interval) =
+    let(
+        m = 8,
+        n = 12,
+        points = getDuctPoints(interval, duct)
+    )
+    concat(
+        drawWhoopAngledBoxDuct(point=points[0], duct=duct, start=10.5, end=16.5, m=m, n=n),
+        drawWhoopAngledBoxDuct(point=points[1], duct=duct, start= 1.5, end= 7.5, m=m, n=n),
+        drawWhoopAngledBoxDuct(point=points[2], duct=duct, start= 4.5, end=10.0, m=m, n=n),
+        drawWhoopAngledBoxDuct(point=points[3], duct=duct, start= 8.0, end=13.5, m=m, n=n)
+    )
+;
+
+/**
+ * Builds a box that will contain a tiny-whoop.
+ * Angled version.
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number wallThickness - The thickness of the walls
+ * @param Number groundThickness - The thickness of the ground
+ * @param Number boxHeight - The height of the box
+ * @param Number [ductDistance] - The distance between a duct and the wall
+ */
+module whoopAngledBox(whoopType, wallThickness, groundThickness, boxHeight, ductDistance = 0) {
+    duct = getWhoopDuctDiameter(whoopType) + ductDistance * 2;
+    interval = getWhoopMotorInterval(whoopType);
+    boxWidth = interval + duct + wallThickness * 2;
+    points = drawWhoopAngledBoxShape(duct=duct, interval=interval);
+
+    boxShape(size=apply3D(boxWidth, z=boxHeight), ground=groundThickness) {
+        extrudeShape(points=points, height=boxHeight, distance=wallThickness);
+        extrudeShape(points=points, height=boxHeight);
+    }
+}

--- a/rcmodels/whoop-box/shapes/box-util.scad
+++ b/rcmodels/whoop-box/shapes/box-util.scad
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines box util shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Draws the shape of a box handle indentation.
+ * @param Vector size - The size of the box
+ * @param Vector indentation - The size of the indentation
+ */
+module boxIndentationShape(size, indentation) {
+    size = vector3D(size);
+    indentation = vector2D(indentation);
+    translateZ(size[2] - indentation[1] / 2) {
+        simplePolyhedron(
+            bottom = drawCross(vadd(size, ALIGN2), indentation[1]),
+            top = drawCross(vadd(size, ALIGN2), indentation[0]),
+            z = indentation[1]
+        );
+    }
+}
+
+/**
+ * Draws the shape of a box handle holes.
+ * @param Vector size - The size of the box
+ * @param Vector hole - The size of the hole
+ */
+module boxHoleShape(size, hole) {
+    size = vector3D(size);
+    hole = vector2D(hole);
+
+    translateZ(size[2] / 2) {
+        rotateY(90) {
+            shaft(d=flip(hole), h=size[0] + ALIGN2, center=true);
+        }
+        rotateX(90) {
+            shaft(d=hole, h=size[1] + ALIGN2, center=true);
+        }
+    }
+}
+
+/**
+ * Builds a box shape, with the cut for the handle (indentation).
+ * @param Vector size - The size of the box
+ * @param Number ground - The thickness of the box floor
+ * @param Vector [count] - The number of tiny-whoops on each axis
+ */
+module boxShape(size, ground, count = 1) {
+    difference() {
+        children(0);
+        translateZ(ground) {
+            children(1);
+        }
+        repeatShape2D(size, count, center=true) {
+            boxIndentationShape(size, boxIndentation);
+        }
+    }
+}
+
+/**
+ * Extrudes a shape polygon, taking care of the outline.
+ * @param Vector[] points - The points that define the shape
+ * @param Number height - The height of the shape
+ * @param Number [distance] - The distance to the shape's outline
+ */
+module extrudeShape(points, height, distance = 0) {
+    linear_extrude(height=height, convexity=10) {
+        polygon(distance ? outline(points=points, distance=distance) : points);
+    }
+}

--- a/rcmodels/whoop-box/shapes/container.scad
+++ b/rcmodels/whoop-box/shapes/container.scad
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines box container shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Computes the points defining the polygon shape of a box that will
+ * contain several tiny-whoops.
+ * @param Number duct - The duct diameter
+ * @param Number interval - The distance between ducts
+ * @param Number [wall] - The thickness of walls between each tiny-whoops
+ * @param Vector [count] - The number of whoops on each axis
+ * @returns Vector[]
+ */
+function drawWhoopContainerShape(duct, interval, wall = 0, count = 1) =
+    let(
+        n = 8,
+        angle = getPolygonAngle(1, n),
+        radius = getDuctRadius(n, duct),
+        count = vector2D(count),
+        width = interval + duct + wall,
+        stepX = [width, 0],
+        stepY = [0, width],
+        point = width * (count - [1, 1]) / 2,
+        points = [ for (i = [0:3]) quadrant(point, i) ],
+        ducts = [ for (i = [0:3]) quadrant(interval, i) / 2 ],
+        length = count * 4 - [2, 2]
+    )
+    concat(
+        // point 1
+        [
+            for (c = [1 : length[0]])
+                let(
+                    i = floor(c / 4),
+                    j = c % 4
+                )
+                points[0] - stepX * i + ducts[floor(j / 2) % 4] + arcp(radius, angle * (j + 0.5))
+        ],
+        // point 2
+        [
+            for (c = [1 : length[1]])
+                let(
+                    i = floor(c / 4),
+                    j = c % 4
+                )
+                points[1] - stepY * i + ducts[floor((2 + j) / 2) % 4] + arcp(radius, angle * (j + 2.5))
+        ],
+        // point 3
+        [
+            for (c = [1 : length[0]])
+                let(
+                    i = floor(c / 4),
+                    j = c % 4
+                )
+                points[2] + stepX * i + ducts[floor((4 + j) / 2) % 4] + arcp(radius, angle * (j + 4.5))
+        ],
+        // point 4
+        [
+            for (c = [1 : length[1]])
+                let(
+                    i = floor(c / 4),
+                    j = c % 4
+                )
+                points[3] + stepY * i + ducts[floor((6 + j) / 2) % 4] + arcp(radius, angle * (j + 6.5))
+        ]
+    )
+;
+
+/**
+ * Builds a box that will contain several tiny-whoops.
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number wallThickness - The thickness of the walls
+ * @param Number groundThickness - The thickness of the ground
+ * @param Number boxHeight - The height of the box
+ * @param Number [ductDistance] - The distance between a duct and the wall
+ * @param Vector [whoopCount] - The number of tiny-whoops on each axis
+ */
+module whoopContainer(whoopType, wallThickness, groundThickness, boxHeight, ductDistance = 0, whoopCount = 1) {
+    duct = getWhoopDuctDiameter(whoopType) + ductDistance * 2;
+    interval = getWhoopMotorInterval(whoopType);
+    boxWidth = interval + duct + wallThickness * 2;
+    innerWidth = boxWidth - wallThickness;
+
+    boxShape(size=apply3D(boxWidth, z=boxHeight), ground=groundThickness, count=whoopCount) {
+        extrudeShape(points=drawWhoopContainerShape(
+            duct = duct,
+            interval = interval,
+            wall = wallThickness,
+            count = whoopCount
+        ), height=boxHeight, distance=wallThickness);
+
+        repeatShape2D(innerWidth, whoopCount, center=true) {
+            extrudeShape(points=drawWhoopContainerShape(
+                duct = duct,
+                interval = interval
+            ), height=boxHeight);
+        }
+    }
+}

--- a/rcmodels/whoop-box/shapes/cupboard.scad
+++ b/rcmodels/whoop-box/shapes/cupboard.scad
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines cupboard shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Computes the points defining the polygon shape of a cupboatd that will
+ * contain drawers for several tiny-whoops.
+ * @param Number duct - The duct diameter
+ * @param Number interval - The distance between ducts
+ * @param Number [wall] - The thickness of walls between each tiny-whoops
+ * @param Number [offset] - The offset for the bottom side
+ * @param Vector [count] - The number of whoops on each axis
+ * @returns Vector[]
+ */
+function drawWhoopCupboardShape(duct, interval, wall = 0, offset = 0, count = 1) =
+    let(
+        n = 8,
+        count = vector2D(count),
+        radius = getDuctRadius(n, duct),
+        points = getDuctPoints(interval, duct, count, wall),
+        offset = [0, offset]
+    )
+    [
+        for (i = [0 : n  - 1])
+            points[floor(i / 2)] + arcp(radius, getPolygonAngle(i + 0.5, n)) + [0, offset[floor(i / 4)]]
+    ]
+;
+
+/**
+ * Builds a cupboatd that will contain drawers for several tiny-whoops.
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number drawerWallThickness - The thickness of the internal walls
+ * @param Number wallThickness - The thickness of the walls
+ * @param Number drawerHeight - The height of a drawer
+ * @param Number [ductDistance] - The distance between a duct and a drawer's wall
+ * @param Number [drawerDistance] - The distance between a drawer and the wall
+ * @param Number [drawerCount] - The number of drawers
+ * @param Vector [whoopCount] - The number of tiny-whoops on each axis
+ */
+module whoopCupboard(whoopType, drawerWallThickness, wallThickness, drawerHeight, ductDistance = 0, drawerDistance = 0, drawerCount = 1, whoopCount = 1) {
+    duct = getWhoopDuctDiameter(whoopType) + ductDistance * 2;
+    interval = getWhoopMotorInterval(whoopType);
+    cupboardWidth = getDuctDistance(interval, duct, whoopCount, drawerWallThickness)[0] + duct + (drawerWallThickness + drawerDistance + wallThickness) * 2;
+    fullHeight = (drawerHeight + wallThickness) * drawerCount + wallThickness;
+
+    rotateX(270) {
+        translate(-[0, cupboardWidth, fullHeight] / 2) {
+            difference() {
+                extrudeShape(points=drawWhoopCupboardShape(
+                    duct = duct,
+                    interval = interval,
+                    wall = drawerWallThickness,
+                    offset = drawerDistance + wallThickness,
+                    count = whoopCount
+                ), height=fullHeight, distance=drawerWallThickness + drawerDistance + wallThickness);
+
+                translateZ(wallThickness) {
+                    repeat(count=drawerCount, interval = [0, 0, drawerHeight + wallThickness]) {
+                        extrudeShape(points=drawWhoopCupboardShape(
+                            duct = duct,
+                            interval = interval,
+                            wall = drawerWallThickness,
+                            offset = -wallThickness,
+                            count = whoopCount
+                        ), height=drawerHeight, distance=drawerWallThickness + drawerDistance);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rcmodels/whoop-box/shapes/drawer.scad
+++ b/rcmodels/whoop-box/shapes/drawer.scad
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines drawer shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Computes the points defining the polygon shape of a drawer that will contain
+ * several tiny-whoops.
+ * @param Number duct - The duct diameter
+ * @param Number interval - The distance between ducts
+ * @param Number [wall] - The thickness of walls between each tiny-whoops
+ * @param Vector [count] - The number of whoops on each axis
+ * @returns Vector[]
+ */
+function drawWhoopDrawerShape(duct, interval, wall = 0, count = 1) =
+    let(
+        n = 8,
+        count = vector2D(count),
+        radius = getDuctRadius(n, duct),
+        points = getDuctPoints(interval, duct, count, wall)
+    )
+    [
+        for (i = [0 : n  - 1])
+            points[floor(i / 2)] + arcp(radius, getPolygonAngle(i + 0.5, n))
+    ]
+;
+
+/**
+ * Builds a drawer that will contain several tiny-whoops.
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number wallThickness - The thickness of the walls
+ * @param Number groundThickness - The thickness of the ground
+ * @param Number boxHeight - The height of the box
+ * @param Number [ductDistance] - The distance between a duct and the wall
+ * @param Vector [whoopCount] - The number of tiny-whoops on each axis
+ */
+module whoopDrawer(whoopType, wallThickness, groundThickness, boxHeight, ductDistance = 0, whoopCount = 1) {
+    duct = getWhoopDuctDiameter(whoopType) + ductDistance * 2;
+    interval = getWhoopMotorInterval(whoopType);
+    boxWidth = interval + duct + wallThickness * 2;
+    innerWidth = boxWidth - wallThickness;
+
+    boxShape(size=apply3D(boxWidth, z=boxHeight), ground=groundThickness, count=whoopCount) {
+        extrudeShape(points=drawWhoopDrawerShape(
+            duct = duct,
+            interval = interval,
+            wall = wallThickness,
+            count = whoopCount
+        ), height=boxHeight, distance=wallThickness);
+
+        repeatShape2D(innerWidth, whoopCount, center=true) {
+            extrudeShape(points=drawWhoopDrawerShape(
+                duct = duct,
+                interval = interval
+            ), height=boxHeight);
+        }
+    }
+}

--- a/rcmodels/whoop-box/shapes/rounded-box.scad
+++ b/rcmodels/whoop-box/shapes/rounded-box.scad
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines rounded box shapes.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Computes the points defining a duct outline.
+ * Rounded version.
+ * @param Vector point - The center of the duct
+ * @param Number duct - The duct diameter
+ * @param Number start - The start sector
+ * @param Number end - The end sector
+ * @param Number n - The number of sectors
+ * @returns Vector[]
+ */
+function drawWhoopRoundedBoxDuct(point, duct, start, end, n = 12) =
+    let(
+        point = vector2D(point),
+        radius = float(duct) / 2,
+        angle = getPolygonAngle(1, n),
+        start = float(start) * angle,
+        end = float(end) * angle
+    )
+    arc(r=radius, o=point, a1=start, a2=end)
+;
+
+/**
+ * Computes the points defining the polygon shape surrounding a tiny-whoop.
+ * Rounded version.
+ * @param Number duct - The duct diameter
+ * @param Number interval - The distance between ducts
+ * @returns Vector[]
+ */
+function drawWhoopRoundedBoxShape(duct, interval) =
+    let(
+        n = 12,
+        radius = duct / 2,
+        angle = getPolygonAngle(1, n),
+        points = getDuctPoints(interval, duct)
+    )
+    concat(
+        drawWhoopRoundedBoxDuct(point=points[0], duct=duct, start=-1.5, end= 4.5, n=n),
+        drawWhoopRoundedBoxDuct(point=points[1], duct=duct, start= 1.5, end= 7.5, n=n),
+        drawWhoopRoundedBoxDuct(point=points[2], duct=duct, start= 4.5, end=10.0, n=n),
+        drawWhoopRoundedBoxDuct(point=points[3], duct=duct, start=-4.0, end= 1.5, n=n)
+    )
+;
+
+/**
+ * Builds a box that will contain a tiny-whoop.
+ * Rounded version.
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number wallThickness - The thickness of the walls
+ * @param Number groundThickness - The thickness of the ground
+ * @param Number boxHeight - The height of the box
+ * @param Number [ductDistance] - The distance between a duct and the wall
+ */
+module whoopRoundedBox(whoopType, wallThickness, groundThickness, boxHeight, ductDistance = 0) {
+    duct = getWhoopDuctDiameter(whoopType) + ductDistance * 2;
+    interval = getWhoopMotorInterval(whoopType);
+    boxWidth = interval + duct + wallThickness * 2;
+    points = drawWhoopRoundedBoxShape(duct=duct, interval=interval);
+
+    boxShape(size=apply3D(boxWidth, z=boxHeight), ground=groundThickness) {
+        extrudeShape(points=points, height=boxHeight, distance=wallThickness);
+        extrudeShape(points=points, height=boxHeight);
+    }
+}

--- a/rcmodels/whoop-box/test/all-box.scad
+++ b/rcmodels/whoop-box/test/all-box.scad
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Draws a box following the outline shape of a tiny-whoop.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// Import the project's setup.
+include <../util/setup.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+// Displays a build box visualization to preview the printer area.
+buildBox(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 5])
+    union() {
+        whoopContainer(
+            whoopType = whoopType,
+            wallThickness = getBoxWallThickness(CONTAINER),
+            groundThickness = getBoxGroundThickness(CONTAINER),
+            boxHeight = getBoxHeight(CONTAINER, whoopType),
+            ductDistance = getBoxWhoopDistance(CONTAINER)
+        );
+        translateZ(getBoxGroundThickness(CONTAINER)) {
+            whoopAngledBox(
+                whoopType = whoopType,
+                wallThickness = getBoxWallThickness(ANGLED_BOX),
+                groundThickness = getBoxGroundThickness(ANGLED_BOX),
+                boxHeight = getBoxHeight(ANGLED_BOX, whoopType),
+                ductDistance = getBoxWhoopDistance(ANGLED_BOX)
+            );
+            translateZ(getBoxGroundThickness(ANGLED_BOX)) {
+                whoopRoundedBox(
+                    whoopType = whoopType,
+                    wallThickness = getBoxWallThickness(ROUNDED_BOX),
+                    groundThickness = getBoxGroundThickness(ROUNDED_BOX),
+                    boxHeight = getBoxHeight(ROUNDED_BOX, whoopType),
+                    ductDistance = getBoxWhoopDistance(ROUNDED_BOX)
+                );
+            }
+        }
+    }
+}

--- a/rcmodels/whoop-box/util/functions.scad
+++ b/rcmodels/whoop-box/util/functions.scad
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store tiny-whoops.
+ *
+ * Defines some functions.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+/**
+ * Ajust a height with respect to the target layer height
+ * @param Number height
+ * @returns Number
+ */
+function adjustToLayer(height) = roundBy(height, printResolution);
+
+/**
+ * Ajust a width with respect to the target nozzle size
+ * @param Number width
+ * @returns Number
+ */
+function adjustToNozzle(width) = roundBy(width, nozzle);
+
+/**
+ * Gets the data defined for a particular tiny-whoop type
+ * @param String whoopType - The type of tiny-whoop
+ * @param Number [index] - The index of the data to get
+ * @returns Array|Number - The tiny-whoop data
+ */
+function getWhoopData(whoopType, index) =
+    let(
+        data = fetch(whoopData, whoopType)
+    )
+    index ? data[index] : data
+;
+
+/**
+ * Gets the data defined for a particular box type
+ * @param String boxType - The type of box
+ * @param Number [index] - The index of the data to get
+ * @returns Array|Number - The box data
+ */
+function getBoxData(boxType, index) =
+    let(
+        data = fetch(boxData, boxType)
+    )
+    index ? data[index] : data
+;
+
+/**
+ * Gets the cumulative data defined for a particular box type
+ * @param String boxType - The type of box
+ * @param Number index - The index of the data to sum
+ * @returns Number - The box cumulative data
+ */
+function getBoxCumulativeData(boxType, index) =
+    let(
+        dataIndex = find(boxData, boxType)
+    )
+    vsum([
+        for (boxIndex = [0:dataIndex])
+            boxData[boxIndex][index]
+    ])
+;
+
+/**
+ * Gets the list of box types till the provided one
+ * @param String boxType - The type of box
+ * @returns Array - The box cumulative data
+ */
+function getBoxTypeList(boxType) =
+    let(
+        dataIndex = find(boxData, boxType)
+    )
+    [
+        for (boxIndex = [0:dataIndex])
+            boxData[boxIndex][IDX_ID]
+    ]
+;
+
+/**
+ * Gets the diameter of the propeller duct
+ * @param String whoopType - The type of tiny-whoop for which compute the size
+ * @returns Number - The diameter of the propeller duct
+ */
+function getWhoopDuctDiameter(whoopType) = getWhoopData(whoopType, IDX_WHOOP_DUCT);
+
+/**
+ * Computes the distance between motors based on the diagonal size of a tiny-whoop frame
+ * @param String whoopType - The type of tiny-whoop for which compute the size
+ * @returns Number - The distance between motors
+ */
+function getWhoopMotorInterval(whoopType) =
+    sqrt(pow(getWhoopData(whoopType, IDX_WHOOP_FRAME), 2) / 2)
+;
+
+/**
+ * Gets the height of a tiny-whoop
+ * @param String whoopType - The type of tiny-whoop
+ * @returns Number - The height of the tiny-whoop
+ */
+function getWhoopHeight(whoopType) = adjustToLayer(
+    getWhoopData(whoopType, IDX_WHOOP_HEIGHT)
+);
+
+/**
+ * Gets the ground thickness
+ * @param String boxType - The type of box
+ * @returns Number - The ground thickness for the given box
+ */
+function getBoxGroundThickness(boxType) = adjustToLayer(
+    getBoxData(boxType, IDX_BOX_GROUND)
+);
+
+/**
+ * Gets the wall thickness
+ * @param String boxType - The type of box
+ * @returns Number - The wall thickness for the given box
+ */
+function getBoxWallThickness(boxType) = adjustToNozzle(
+    getBoxData(boxType, IDX_BOX_WALL)
+);
+
+/**
+ * Gets the distance from the internal space to walls
+ * @param String boxType - The type of box
+ * @returns Number - The distance to walls for the given box
+ */
+function getBoxWallDistance(boxType) = wallDistance * getBoxData(boxType, IDX_BOX_DISTANCE);
+
+/**
+ * Gets the distance from the tiny-whoop ducts to walls
+ * @param String boxType - The type of box
+ * @returns Number - The distance to walls for the given box
+ */
+function getBoxWhoopDistance(boxType) =
+    wallDistance * getBoxCumulativeData(boxType, IDX_BOX_DISTANCE) +
+    vsum([
+        for (type = pop(getBoxTypeList(boxType)))
+            getBoxWallThickness(type)
+    ])
+;
+
+/**
+ * Gets the height of a box with respect to the given tiny-whoop
+ * @param String boxType - The type of box
+ * @param String whoopType - The type of tiny-whoop
+ * @returns Number - The height of the box
+ */
+function getBoxHeight(boxType, whoopType) =
+    getWhoopHeight(whoopType) +
+    adjustToLayer(getBoxData(boxType, IDX_BOX_HEIGHT)) +
+    vsum([
+        for (type = getBoxTypeList(boxType))
+            getBoxGroundThickness(type)
+    ])
+;
+
+/**
+ * Gets the radius of a tiny-whoop duct.
+ * @param Number sides - The number of sides of the duct
+ * @param Number diameter - The diameter of the duct
+ * @returns Vector - The radius of the duct, as a 2D vector
+ */
+function getDuctRadius(sides, diameter) =
+    vector2D(
+        circumradius(n=sides, a=float(diameter) / 2)
+    )
+;
+
+/**
+ * Gets the distance between external ducts, for one or more tiny-whoops.
+ * @param Number interval - The interval between ducts
+ * @param Number diameter - The diameter of a duct
+ * @param Vector count - The count of tiny-whoops in each direction
+ * @param Number wall - The thickness of a wall
+ * @returns Vector - The distance betwenn external ducts
+ */
+function getDuctDistance(interval, diameter, count = 1, wall = 0) =
+    let(
+        count = vector2D(count),
+        interval = float(interval),
+        width = interval + float(diameter) + float(wall)
+    )
+    vadd(width * (count - [1, 1]), interval)
+;
+
+/**
+ * Gets the points for each duct of a tiny-whoop.
+ * @param Number interval - The interval between ducts
+ * @param Number diameter - The diameter of a duct
+ * @param Vector count - The count of tiny-whoops in each direction
+ * @param Number wall - The thickness of a wall
+ * @returns Vector - The distance betwenn external ducts
+ */
+function getDuctPoints(interval, diameter, count = 1, wall = 0) =
+    let(
+        point = getDuctDistance(interval, diameter, count, wall) / 2
+    )
+    [ for (i = [0:3])
+        quadrant(point, i)
+    ]
+;

--- a/rcmodels/whoop-box/util/setup.scad
+++ b/rcmodels/whoop-box/util/setup.scad
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2019 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A box to store a tiny whoop.
+ *
+ * Setup the context.
+ *
+ * @author jsconan
+ * @version 0.1.0
+ */
+
+// As we need to use some shapes, use the right entry point of the library.
+include <../../../lib/camelSCAD/shapes.scad>
+
+// Then we need the config for the project, as well as the related functions
+include <../config/config.scad>
+include <functions.scad>
+
+// Finally, include the shapes
+include <../shapes/box-util.scad>
+include <../shapes/rounded-box.scad>
+include <../shapes/angled-box.scad>
+include <../shapes/container.scad>
+include <../shapes/drawer.scad>
+include <../shapes/cupboard.scad>

--- a/skeleton.scad
+++ b/skeleton.scad
@@ -2,7 +2,7 @@
  * @license
  * GPLv3 License
  *
- * Copyright (c) 2017 Jean-Sebastien CONAN
+ * Copyright (c) 2017-2019 Jean-Sebastien CONAN
  *
  * This file is part of jsconan/things.
  *
@@ -37,7 +37,9 @@ include <lib/camelSCAD/core/constants.scad>
 renderMode = MODE_PROD;
 
 // Defines the constraints of the print.
-printResolution = 0.2;
+printResolution = 0.2;  // the target layer height
+nozzle = 0.4;           // the size of the print nozzle
+wallDistance = 0.1;     // the distance between the walls of two objects
 
 // Defines the constraints of the object.
 //count = 2;
@@ -50,5 +52,9 @@ printResolution = 0.2;
 // Sets the minimum facet angle and size using the defined render mode.
 // Displays a build box visualization to preview the printer area.
 buildBox(mode=renderMode) {
-
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    union() {
+        // This is where to define the object
+    }
 }


### PR DESCRIPTION
Released things:
- A small bracket that will hold a LED strip.
- A spool holder that mounts on a cylindric food dehydratator.
- A feet set to put under a cylindric food dehydratator.
- A parametric holder for triominos.
- A spool holder that will be pluggable on the wheels of the adjustable spool holder from the LACK enclosure cabinet.
- A stand for the BetaFPV Beta85X.
- A needle for the BetaFPV Beta85X HD, to activate the camera recording or to remove the SD card.
- Whoop box project: A box to store tiny-whoops.

Updates:
- Updated library [camelSCAD](https://github.com/jsconan/camelSCAD) to `v0.6.0`
- Updated `skeleton.scad`: added more printer constraints, added example to sample the object

Fixes: 
- Fix typo in the name of function `pythagoras()` (was` pythagore()` before)